### PR TITLE
fix(editor): ignore mouse up event on bond action if mouse down was not captured

### DIFF
--- a/src/main/java/com/actelion/research/share/gui/editor/actions/BondBaseAction.java
+++ b/src/main/java/com/actelion/research/share/gui/editor/actions/BondBaseAction.java
@@ -79,6 +79,10 @@ public abstract class BondBaseAction extends BondHighlightAction
 
     public boolean onMouseUp(IMouseEvent evt)
     {
+        // Ignore event if the action didn't start in the editor.
+        if (origin == null) {
+            return false;
+        }
 
         boolean ok = true;
         GenericPoint pt = new GenericPoint(evt.getX(), evt.getY());


### PR DESCRIPTION
The action handler requires a starting point.